### PR TITLE
修复对金额进行序列化时报错

### DIFF
--- a/jingtum_python_baselib/tum_amount.py
+++ b/jingtum_python_baselib/tum_amount.py
@@ -93,7 +93,7 @@ class Amount:
                             # TODO, need to find a better way for extracting the exponent and digits
                             vpow = float(in_json['value'])
                             vpow = str("%e"%vpow)
-                            vpow = vpow[vpow.rfind("e") + 1:].replace("0", "")
+                            vpow = vpow[vpow.rfind("e") + 1:]
                             offset = 15 - int(vpow)
                             factor = math.pow(10, offset)
                             self._value = int(float(in_json['value'])*factor)
@@ -112,6 +112,7 @@ class Amount:
     # with precision
     def parse_swt_value(self, j):
         if isinstance(j, str):
+            j = '%.6f' % float(j)
             m = re.match('^(-?)(\d*)(\.\d{0,6})?$', j)
         if m:
             if m.group(3) is None:


### PR DESCRIPTION
1.对指数的+00替换为+，然后转为int会导致异常
2.对float进行str操作转为了科学计数法表示，然后使用正则匹配未能匹配成功